### PR TITLE
Suggestions on review

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,6 @@ inputs:
     description: "DDEV Version to use"
     options:
       - stable
-      - edge
       - HEAD
 
 
@@ -44,7 +43,7 @@ runs:
 
     - name: Download docker images
       shell: bash
-      run: mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
+      run: ddev debug download-images >/dev/null
 
 
 branding:


### PR DESCRIPTION
Finally got there!

* `ddev debug download-images` now works without a project
* I don't think we need more than stable and HEAD, but open to edge. 
* Goland is convinced there's something wrong with the ddev-version values:

<img width="464" alt="image" src="https://github.com/julienloizelet/ddev-add-on-test-init/assets/112444/464a9cf5-0daa-48be-9c3a-38d8f2e186dc">
